### PR TITLE
fix threading in video player while navigating back

### DIFF
--- a/core/src/main/java/com/lukakordzaia/core/videoplayer/VideoPlayerViewModel.kt
+++ b/core/src/main/java/com/lukakordzaia/core/videoplayer/VideoPlayerViewModel.kt
@@ -14,7 +14,9 @@ import com.lukakordzaia.core.network.Result
 import com.lukakordzaia.core.network.models.imovies.request.user.PostTitleWatchTimeRequestBody
 import com.lukakordzaia.core.network.toEpisodeInfoModel
 import com.lukakordzaia.core.utils.Event
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 
 class VideoPlayerViewModel : BaseViewModel() {
@@ -90,7 +92,9 @@ class VideoPlayerViewModel : BaseViewModel() {
                 }
             } else {
                 viewModelScope.launch {
-                    environment.databaseRepository.insertContinueWatchingInRoom(dbDetails)
+                    withContext(Dispatchers.IO) {
+                        environment.databaseRepository.insertContinueWatchingInRoom(dbDetails)
+                    }
                 }
             }
         } else {
@@ -131,7 +135,7 @@ class VideoPlayerViewModel : BaseViewModel() {
 
         data.episodeFiles?.forEach {
             if (chosenLanguage.equals(it.fileLanguage, true)) {
-                episodeLink =  it.fileUrl
+                episodeLink = it.fileUrl
             }
         }
 

--- a/streamflowtv/src/main/java/com/lukakordzaia/streamflowtv/ui/tvsingletitle/tvtitledetails/TvTitleDetailsViewModel.kt
+++ b/streamflowtv/src/main/java/com/lukakordzaia/streamflowtv/ui/tvsingletitle/tvtitledetails/TvTitleDetailsViewModel.kt
@@ -11,7 +11,9 @@ import com.lukakordzaia.core.datamodels.SingleTitleModel
 import com.lukakordzaia.core.network.LoadingState
 import com.lukakordzaia.core.network.Result
 import com.lukakordzaia.core.network.toSingleTitleModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TvTitleDetailsViewModel : BaseViewModel() {
     val hideContinueWatchingLoader = MutableLiveData<LoadingState>()
@@ -111,7 +113,9 @@ class TvTitleDetailsViewModel : BaseViewModel() {
 
     fun deleteSingleContinueWatchingFromRoom(titleId: Int) {
         viewModelScope.launch {
-            environment.databaseRepository.deleteSingleContinueWatchingFromRoom(titleId)
+            withContext(Dispatchers.IO) {
+                environment.databaseRepository.deleteSingleContinueWatchingFromRoom(titleId)
+            }
             newToastMessage("წაიშალა ნახვების ისტორიიდან სიიდან")
         }
     }


### PR DESCRIPTION
ვიდეო ფლეიერიდან უკან გამოსვლის დროს `Cannot access database on the main thread since it may potentially lock the UI for a long period of time` ამას აგდებდა და იქრეშებოდა აპლიკაცია