### PR TITLE
fix recently watched rows + string

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
     <string name="saved_movies">შენახული ფილმები</string>
     <string name="saved_tvShows">შენახული სერიალები</string>
     <string name="movies">ფილმები</string>
-    <string name="tv_shows">სერილაები</string>
+    <string name="tv_shows">სერიალები</string>
     <string name="other_episodes">სხვა ეპიზოდები</string>
     <string name="check_internet_connection">შეამოწმეთ ინტერნეტთან კავშირი</string>
     <string name="try_again">სცადეთ თავიდან</string>

--- a/streamflowtv/src/main/java/com/lukakordzaia/streamflowtv/ui/main/TvMainFragment.kt
+++ b/streamflowtv/src/main/java/com/lukakordzaia/streamflowtv/ui/main/TvMainFragment.kt
@@ -120,9 +120,7 @@ class TvMainFragment : BaseBrowseSupportFragment<TvMainViewModel>() {
 
         watchListAdapter = ListRow(HeaderItem(0, getString(R.string.continue_watching)), listRowAdapter)
 
-        if (sharedPreferences.getRefreshContinueWatching()) {
-            setRowsAdapter()
-        }
+        setRowsAdapter()
     }
 
     private fun newMoviesRowsAdapter(items: List<SingleTitleModel>) {
@@ -209,13 +207,13 @@ class TvMainFragment : BaseBrowseSupportFragment<TvMainViewModel>() {
 
         rowsAdapter.addAll(0, row)
     }
-    
+
     private inner class ItemViewClickedListener : OnItemViewClickedListener {
         override fun onItemClicked(
-                itemViewHolder: Presenter.ViewHolder,
-                item: Any,
-                rowViewHolder: RowPresenter.ViewHolder,
-                row: Row
+            itemViewHolder: Presenter.ViewHolder,
+            item: Any,
+            rowViewHolder: RowPresenter.ViewHolder,
+            row: Row
         ) {
             when (item) {
                 is SingleTitleModel -> {


### PR DESCRIPTION
აქამდეც არსებობდა ეს პრობლემა უბრალოდ არ ჩანდა წინა სიტუაციაში. კერძოდ აქამდე რექვესთები რაც გადიოდა იყო მიყოლებით, შემდეგი მეთოდით

```
ახალი ფილმები ->
                              ტოპ ფილმები ->
                                                        ტოპ სერიალები ->
                                                                                      ახალი სერიალები ->

ნანახი ფილმები ------------------->
```
ამავდროულად ცალკე ეშვებოდა უკვე ნანახი ფილმების წამოსაღები სერვისი.

რადგანაც ზედა 4 სერვისი უფრო დიდი ხანი ანდომებდა ჩატვირთვას, ნანახი ფილმები უფრო მალე იტვირთებოდა და ავსებდა livedata-ს ინფორმაციით და hasContinueWatching ამ მნიშვნელობასაც. როდესაც 4 სერვისიდან მოსული პასუხი საბოლოოდ დახატავდა მთავარ გვერდს იქვე ქონდათ ყველა წინა ინფორმაცია ნანახ ფილმებზე და ერთიანად ხატავდა.

ჩემი წინა PR #88 -მა შეცვალა ეს ქცევა და ახლა უშვებს 4-ივე რექვესტს პარალელურად რამაც მნიშვნელოვნად აასწრაფა ჩატვირთვის სიჩქარე. ახლა ვიღებთ ასეთ სურათს: 

```
ახალი ფილმები ->
ტოპ ფილმები ->
ტოპ სერიალები ->
ახალი სერიალები ->

ნანახი ფილმები ------------------------->
```
**რას ნიშნავს ეს?**
როდესაც ფრაგმენტში მივა 4-ივე ჩატვირთული სერვისი მათ არ ხვდებათ ნანახი ფილმების ინფორმაცია და მის გარეშე ტვირთავენ მთავარ გვერდს, როდესაც ნანახი ფილმების ინფორმაცია მოვა, კი იკვრება მთლიანობაში მთავარი გვერდი მაგრამ არ აისახება ეგ ადაპტერზე რადგანაც ქვემოთმოცემული კოდი ბლოკავს.
```
if (sharedPreferences.getRefreshContinueWatching()) {
    setRowsAdapter()
}
```
ამ წუთას ეს კოდი არ არის საჭირო რადგან onStart-ში მსგავსი შემოწმება უკვე დევს.

არ არის იდეალური გადაჭრა მაგრამ იდეალური შედეგისთვის ბევრი სხვა რამეა გადასააზრებელი როგორ გაეშვას რექვესთები.